### PR TITLE
Added --color and --format documentation rspec options

### DIFF
--- a/lib/busser/serverspec/runner.rb
+++ b/lib/busser/serverspec/runner.rb
@@ -42,6 +42,7 @@ RSpec::Core::RakeTask.new(:spec) do |t|
   end
 
   t.rspec_path = rspec_bin if rspec_bin
+  t.rspec_opts = ['--color', '--format documentation']
   t.ruby_opts = "-I#{base_path}"
   t.pattern = "#{base_path}/**/*_spec.rb"
 end


### PR DESCRIPTION
Adding the `--color` and `--format documentation` really helps reading through the logs. I didn't seem to find a way on configuring these options elsewhere so added it here. Also I don't think it is going to hurt anybody.
