### PR TITLE
Travis build test following serverspec v2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # <a name="title"></a> Busser::RunnerPlugin::Serverspec
 
+Triggering CI to test serverspec v2.0
+
 [![Gem Version](https://badge.fury.io/rb/busser-serverspec.png)](http://rubygems.org/gems/busser-serverspec) [![Build Status](https://secure.travis-ci.org/test-kitchen/busser-serverspec.png?branch=master)](https://travis-ci.org/test-kitchen/busser-serverspec) [![Dependency Status](https://gemnasium.com/test-kitchen/busser-serverspec.png)](https://gemnasium.com/test-kitchen/busser-serverspec) [![Code Climate](https://codeclimate.com/github/cl-lab-k/busser-serverspec.png)](https://codeclimate.com/github/cl-lab-k/busser-serverspec)
 
 A Busser runner plugin for Serverspec


### PR DESCRIPTION
Hello, I have some issues with busser-serverspec since we release serverspec2.

```
       /opt/chef/embedded/bin/ruby -I/tmp/busser/suites/serverspec -I/tmp/busser/gems/gems/rspec-support-3.0.4/lib:/tmp/busser/gems/gems/rspec-core-3.0.4/lib -S /opt/chef/embedded/bin/rspec /tmp/busser/suites/serverspec/default_spec.rb --color --format documentation
       /tmp/busser/suites/serverspec/spec_helper.rb:4:in `<top (required)>': uninitialized constant Serverspec::Helper::Exec (NameError)
        from /tmp/busser/suites/serverspec/default_spec.rb:3:in `require_relative'
        from /tmp/busser/suites/serverspec/default_spec.rb:3:in `<top (required)>'
        from /tmp/busser/gems/gems/rspec-core-3.0.4/lib/rspec/core/configuration.rb:1058:in `load'
        from /tmp/busser/gems/gems/rspec-core-3.0.4/lib/rspec/core/configuration.rb:1058:in `block in load_spec_files'
        from /tmp/busser/gems/gems/rspec-core-3.0.4/lib/rspec/core/configuration.rb:1058:in `each'
        from /tmp/busser/gems/gems/rspec-core-3.0.4/lib/rspec/core/configuration.rb:1058:in `load_spec_files'
        from /tmp/busser/gems/gems/rspec-core-3.0.4/lib/rspec/core/runner.rb:97:in `setup'
        from /tmp/busser/gems/gems/rspec-core-3.0.4/lib/rspec/core/runner.rb:85:in `run'
        from /tmp/busser/gems/gems/rspec-core-3.0.4/lib/rspec/core/runner.rb:70:in `run'
        from /tmp/busser/gems/gems/rspec-core-3.0.4/lib/rspec/core/runner.rb:38:in `invoke'
        from /tmp/busser/gems/gems/rspec-core-3.0.4/exe/rspec:4:in `<top (required)>'
        from /opt/chef/embedded/bin/rspec:23:in `load'
        from /opt/chef/embedded/bin/rspec:23:in `<main>'
```

this PR is a fake just to trigger travil build
