### PR TITLE
Run bundle with explicit path to ruby bin

### DIFF
--- a/lib/busser/runner_plugin/serverspec.rb
+++ b/lib/busser/runner_plugin/serverspec.rb
@@ -47,7 +47,8 @@ class Busser::RunnerPlugin::Serverspec < Busser::RunnerPlugin::Base
       # the fallback to the internet-enabled version. It's a speed optimization.
       banner('Bundle Installing..')
       ENV['PATH'] = [ENV['PATH'], Gem.bindir, Config::CONFIG['bindir']].join(File::PATH_SEPARATOR)
-      bundle_exec = "bundle install --gemfile #{gemfile_path}"
+      bundle_exec = "#{File.join(Config::CONFIG['bindir'], 'ruby')} " +
+        "#{File.join(Gem.bindir, 'bundle')} install --gemfile #{gemfile_path}"
       run("#{bundle_exec} --local || #{bundle_exec}")
     end
   end


### PR DESCRIPTION
This works around an issue where the .bat binstubs on Windows point to a nonexistent ruby. This enables serverspec to run with a Gemfile on Windows.

Reported in bug: test-kitchen/test-kitchen#616

Obviously, a better way to do this would be to fix the binstubs in the first place, but I was unable to determine how to do this.