### PR TITLE
Run serverspec via bundler to use the version installed by bundler

### DIFF
--- a/lib/busser/runner_plugin/serverspec.rb
+++ b/lib/busser/runner_plugin/serverspec.rb
@@ -33,7 +33,10 @@ class Busser::RunnerPlugin::Serverspec < Busser::RunnerPlugin::Base
     install_serverspec
 
     runner = File.join(File.dirname(__FILE__), %w{.. serverspec runner.rb})
-    run_ruby_script!("#{runner} #{suite_path('serverspec').to_s}")
+    bundle_exec = "#{File.join(RbConfig::CONFIG['bindir'], 'ruby')} " +
+      "#{File.join(Gem.bindir, 'bundle')} exec " +
+      "#{runner}"
+    run("#{bundle_exec}")
   end
 
   private


### PR DESCRIPTION
The busser does a bundle install to create the verify environment, however it does not exec serverspec through that bundle. The end result is that while it looks like it's running code from the bundle, it's just pulling from the system/omnibus install instead. This makes testing new versions of gems (like specinfra to support a new platform) very difficult. This resolves the bug by calling bundle exec on serverspec thus using the bundle as created in the previous step.
