### PR TITLE
Fix frozen string issue when checking Ruby version

### DIFF
--- a/lib/busser/runner_plugin/serverspec.rb
+++ b/lib/busser/runner_plugin/serverspec.rb
@@ -56,7 +56,7 @@ class Busser::RunnerPlugin::Serverspec < Busser::RunnerPlugin::Base
   def install_serverspec
     Gem::Specification.reset
     if Array(Gem::Specification.find_all_by_name('serverspec')).size == 0
-      if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0')
+      if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0')
         banner('Installing net-ssh < 2.10')
         install_gem('net-ssh', '< 2.10')
       end


### PR DESCRIPTION
When using older versions of rubygems, e.g. `1.8.24`, `Gem::Version.new` throws an exception when it's given a frozen string. This works around the problem by using `.dup` to make an unfrozen copy of the frozen `RUBY_VERSION`.

This is needed to fix an issue some coworkers and I ran into while installing this plugin on test-kitchen nodes using the Chef 11.12.8 omnibus, which includes an older rubygems with this frozen string problem.

Here's the exception we're seeing:
```
-----> Running serverspec test suite
       /opt/chef/embedded/lib/ruby/site_ruby/1.9.1/rubygems/version.rb:191:in `strip!': can't modify frozen String (RuntimeError)
        from /opt/chef/embedded/lib/ruby/site_ruby/1.9.1/rubygems/version.rb:191:in `initialize'
        from /tmp/verifier/gems/gems/busser-serverspec-0.6.0/lib/busser/runner_plugin/serverspec.rb:59:in `new'
        from /tmp/verifier/gems/gems/busser-serverspec-0.6.0/lib/busser/runner_plugin/serverspec.rb:59:in `install_serverspec'
        from /tmp/verifier/gems/gems/busser-serverspec-0.6.0/lib/busser/runner_plugin/serverspec.rb:33:in `test'
        from /tmp/verifier/gems/gems/thor-0.19.0/lib/thor/command.rb:27:in `run'
        from /tmp/verifier/gems/gems/thor-0.19.0/lib/thor/invocation.rb:126:in `invoke_command'
        from /tmp/verifier/gems/gems/thor-0.19.0/lib/thor/invocation.rb:133:in `block in invoke_all'
        from /tmp/verifier/gems/gems/thor-0.19.0/lib/thor/invocation.rb:133:in `each'
        from /tmp/verifier/gems/gems/thor-0.19.0/lib/thor/invocation.rb:133:in `map'
        from /tmp/verifier/gems/gems/thor-0.19.0/lib/thor/invocation.rb:133:in `invoke_all'
        from /tmp/verifier/gems/gems/thor-0.19.0/lib/thor/group.rb:232:in `dispatch'
        from /tmp/verifier/gems/gems/thor-0.19.0/lib/thor/invocation.rb:115:in `invoke'
        from /tmp/verifier/gems/gems/busser-0.7.1/lib/busser/command/test.rb:43:in `block in perform'
        from /tmp/verifier/gems/gems/busser-0.7.1/lib/busser/command/test.rb:35:in `each'
        from /tmp/verifier/gems/gems/busser-0.7.1/lib/busser/command/test.rb:35:in `perform'
        from /tmp/verifier/gems/gems/thor-0.19.0/lib/thor/command.rb:27:in `run'
        from /tmp/verifier/gems/gems/thor-0.19.0/lib/thor/invocation.rb:126:in `invoke_command'
        from /tmp/verifier/gems/gems/thor-0.19.0/lib/thor/invocation.rb:133:in `block in invoke_all'
        from /tmp/verifier/gems/gems/thor-0.19.0/lib/thor/invocation.rb:133:in `each'
        from /tmp/verifier/gems/gems/thor-0.19.0/lib/thor/invocation.rb:133:in `map'
        from /tmp/verifier/gems/gems/thor-0.19.0/lib/thor/invocation.rb:133:in `invoke_all'
        from /tmp/verifier/gems/gems/thor-0.19.0/lib/thor/group.rb:232:in `dispatch'
        from /tmp/verifier/gems/gems/thor-0.19.0/lib/thor/invocation.rb:115:in `invoke'
        from /tmp/verifier/gems/gems/thor-0.19.0/lib/thor.rb:40:in `block in register'
        from /tmp/verifier/gems/gems/thor-0.19.0/lib/thor/command.rb:27:in `run'
        from /tmp/verifier/gems/gems/thor-0.19.0/lib/thor/invocation.rb:126:in `invoke_command'
        from /tmp/verifier/gems/gems/thor-0.19.0/lib/thor.rb:359:in `dispatch'
        from /tmp/verifier/gems/gems/thor-0.19.0/lib/thor/base.rb:440:in `start'
        from /tmp/verifier/gems/gems/busser-0.7.1/bin/busser:8:in `<top (required)>'
        from /tmp/verifier/gems/bin/busser:23:in `load'
        from /tmp/verifier/gems/bin/busser:23:in `<main>'
```