### PR TITLE
Dup RUBY_VERSION to work around trying to manipulate frozen string.

### DIFF
--- a/lib/busser/runner_plugin/serverspec.rb
+++ b/lib/busser/runner_plugin/serverspec.rb
@@ -56,7 +56,7 @@ class Busser::RunnerPlugin::Serverspec < Busser::RunnerPlugin::Base
   def install_serverspec
     Gem::Specification.reset
     if Array(Gem::Specification.find_all_by_name('serverspec')).size == 0
-      if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0')
+      if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0')
         banner('Installing net-ssh < 2.10')
         install_gem('net-ssh', '< 2.10')
       end


### PR DESCRIPTION
I was seeing the following error with 0.6.0 of the busser-servespec gem:

```
-----> Running serverspec test suite
       /opt/chef/embedded/lib/ruby/site_ruby/1.9.1/rubygems/version.rb:191:in `strip!': can't modify frozen String (RuntimeError)
       	from /opt/chef/embedded/lib/ruby/site_ruby/1.9.1/rubygems/version.rb:191:in `initialize'
       	from /tmp/verifier/gems/gems/busser-serverspec-0.6.0/lib/busser/runner_plugin/serverspec.rb:59:in `new'
       	from /tmp/verifier/gems/gems/busser-serverspec-0.6.0/lib/busser/runner_plugin/serverspec.rb:59:in `install_serverspec'
       	from /tmp/verifier/gems/gems/busser-serverspec-0.6.0/lib/busser/runner_plugin/serverspec.rb:33:in `test'
```

Digging into it its due to RubyGems::Version trying to strip RUBY_VERSION which is frozen, sending in a dup works around the issue.