### PR TITLE
Make rake and rspec/core runtime deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,8 @@ sudo: false
 cache: bundler
 
 rvm:
-- 2.2.0
-- 2.1.0
+- 2.3.1
+- 2.2.5
+- 2.1.9
 - 2.0.0
-- 1.9.3
-- ruby-head
-
-matrix:
-  allow_failures:
-  - rvm: ruby-head
+- 1.9.7

--- a/busser-serverspec.gemspec
+++ b/busser-serverspec.gemspec
@@ -19,11 +19,12 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'busser'
+  spec.add_dependency 'rake'
+  spec.add_dependency 'rspec-core'
 
   spec.add_development_dependency 'serverspec'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
-  spec.add_development_dependency 'rake'
   spec.add_development_dependency 'aruba'
 
   spec.add_development_dependency 'cane'


### PR DESCRIPTION
(since we require them at runtime)

This is required to get serverspec working from the new Ruby 2.3 package.