### PR TITLE
Pin rake to < 12.3.0 for ruby < 2.0

### DIFF
--- a/busser-serverspec.gemspec
+++ b/busser-serverspec.gemspec
@@ -42,5 +42,9 @@ Gem::Specification.new do |spec|
   if RUBY_VERSION < '2.0'
     spec.add_development_dependency 'net-ssh', '< 2.10'
     spec.add_development_dependency 'tins', '< 1.7'
+    spec.add_development_dependency 'nokogiri', '< 1.7.0'
+    spec.add_development_dependency 'mime-types', '< 3.0'
+    spec.add_development_dependency 'term-ansicolor', '< 1.4.0'
+    spec.add_development_dependency 'rest-client', '< 2.0'
   end
 end

--- a/busser-serverspec.gemspec
+++ b/busser-serverspec.gemspec
@@ -19,7 +19,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'busser'
-  spec.add_dependency 'rake'
+  if RUBY_VERSION < '2.0'
+    spec.add_dependency 'rake', '< 12.3.0'
+  else
+    spec.add_dependency 'rake'
+  end
   spec.add_dependency 'rspec-core'
 
   spec.add_development_dependency 'serverspec'


### PR DESCRIPTION
Chef 11 uses embedded ruby 1.9. Rake 12.3.0 dropped support for Ruby < 2.0.