### PR TITLE
preinstall net-ssh 4.2 since it is the last version that works in rub…

### DIFF
--- a/lib/busser/runner_plugin/serverspec.rb
+++ b/lib/busser/runner_plugin/serverspec.rb
@@ -56,13 +56,22 @@ class Busser::RunnerPlugin::Serverspec < Busser::RunnerPlugin::Base
   def install_serverspec
     Gem::Specification.reset
     if Array(Gem::Specification.find_all_by_name('serverspec')).size == 0
-      if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0')
-        banner('Installing net-ssh < 2.10')
-        install_gem('net-ssh', '< 2.10')
+      # pre-install net-ssh so rubygems does not pick an incompatible version
+      ruby_version = Gem::Version.new(RUBY_VERSION.dup)
+      if ruby_version < Gem::Version.new('2.0')
+        install_net_ssh '< 2.10'
+      elsif ruby_version < Gem::Version.new('2.2')
+        install_net_ssh '< 5'
       end
+
       banner('Installing Serverspec..')
       spec = install_gem('serverspec')
       banner "serverspec installed (version #{spec.version})"
     end
+  end
+
+  def install_net_ssh(version)
+    banner("Installing net-ssh #{version}")
+    install_gem('net-ssh', version)
   end
 end


### PR DESCRIPTION
…y 2.0/2.1

similar to https://github.com/test-kitchen/busser-serverspec/pull/37


@cl-lab-k @biinari @jorhett @bdeitte

```
       /opt/chef/embedded/lib/ruby/site_ruby/2.1.0/rubygems/installer.rb:605:in `ensure_required_ruby_version_met': net-ssh requires Ruby version >= 2.2.6. (Gem::InstallError)
       	from /opt/chef/embedded/lib/ruby/site_ruby/2.1.0/rubygems/installer.rb:821:in `pre_install_checks'
       	from /opt/chef/embedded/lib/ruby/site_ruby/2.1.0/rubygems/installer.rb:279:in `install'
       	from /opt/chef/embedded/lib/ruby/site_ruby/2.1.0/rubygems/resolver/specification.rb:97:in `install'
       	from /opt/chef/embedded/lib/ruby/site_ruby/2.1.0/rubygems/request_set.rb:166:in `block in install'
       	from /opt/chef/embedded/lib/ruby/site_ruby/2.1.0/rubygems/request_set.rb:156:in `each'
       	from /opt/chef/embedded/lib/ruby/site_ruby/2.1.0/rubygems/request_set.rb:156:in `install'
       	from /opt/chef/embedded/lib/ruby/site_ruby/2.1.0/rubygems/dependency_installer.rb:405:in `install'
       	from /tmp/verifier/gems/gems/busser-0.7.1/lib/busser/rubygems.rb:44:in `install_gem'
       	from /tmp/verifier/gems/gems/busser-0.7.1/lib/busser/helpers.rb:57:in `install_gem'
       	from /tmp/verifier/gems/gems/busser-serverspec-0.5.10/lib/busser/runner_plugin/serverspec.rb:64:in `install_serverspec'
       	from /tmp/verifier/gems/gems/busser-serverspec-0.5.10/lib/busser/runner_plugin/serverspec.rb:33:in `test'
```