### PR TITLE
Pin bundler to the 1.x release.

### DIFF
--- a/lib/busser/runner_plugin/serverspec.rb
+++ b/lib/busser/runner_plugin/serverspec.rb
@@ -25,7 +25,7 @@ require 'rubygems/dependency_installer'
 #
 class Busser::RunnerPlugin::Serverspec < Busser::RunnerPlugin::Base
   postinstall do
-    install_gem('bundler')
+    install_gem('bundler', '~> 1.17')
   end
 
   def test


### PR DESCRIPTION
The `2.x` release of `bundler` brought in a number of breaking changes:
- RubyGems must now be updated to the latest release for `bundler` to work.
- Updating RubyGems breaks other commands in `busser-serverspec` because `--no-rdoc` is longer a valid switch.

Solution here is to install only the old `1.x` release series of `bundler`. Tested locally with a manual `sed`:
```
sudo sed -i "28s/install_gem('bundler')/install_gem('bundler', '~> 1.17')/" /tmp/verifier/gems/gems/busser-serverspec-0.5.10/lib/busser/runner_plugin/serverspec.rb
```

Fixes #53 