### PR TITLE
test: cover the rspec binary discovery

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,8 @@ group :test do
   gem "aruba", ">= 2.4"
   gem "base64", ">= 0.3" # cucumber needs it; not a default gem on Ruby 4.0
   gem "cucumber", ">= 11.1"
+  gem "minitest", ">= 6.0"
+  gem "mocha", ">= 2.7"
   gem "rake", ">= 13.4"
   gem "serverspec", ">= 2.43"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,11 @@
 require "bundler/gem_tasks"
+require "rake/testtask"
+Rake::TestTask.new(:unit) do |t|
+  t.libs.push "lib"
+  t.test_files = FileList["spec/**/*_spec.rb"]
+  t.verbose = true
+end
+
 require "cucumber/rake/task"
 
 Cucumber::Rake::Task.new(:features) do |t|
@@ -6,6 +13,6 @@ Cucumber::Rake::Task.new(:features) do |t|
 end
 
 desc "Run all test suites"
-task test: [:features]
+task test: %i{unit features}
 
 task default: [:test]

--- a/lib/busser/serverspec/rspec_binary.rb
+++ b/lib/busser/serverspec/rspec_binary.rb
@@ -1,0 +1,54 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "rbconfig" unless defined?(RbConfig)
+
+module Busser
+  module Serverspec
+    # Locates the rspec executable to run the suite with.
+    #
+    # The machine under test may have several Ruby installations and several
+    # gem paths, and RSpec::Core::RakeTask would otherwise just shell out to
+    # whatever `rspec` is on PATH -- which may belong to a different Ruby than
+    # the one Busser installed serverspec into.
+    #
+    # This lives apart from runner.rb because that file is a script: requiring
+    # it runs the suite.
+    module RspecBinary
+      module_function
+
+      # Directories that might hold an rspec executable, most specific first.
+      #
+      # @param gem_paths [Array<String>] gem paths to search, defaulting to the
+      #   current RubyGems configuration
+      # @param ruby_bindir [String] the running Ruby's bindir; injectable so
+      #   tests do not depend on what the host Ruby happens to have installed
+      # @return [Array<String>] candidate bin directories
+      def candidate_bindirs(gem_paths = Gem.paths.path, ruby_bindir = RbConfig::CONFIG["bindir"])
+        [ruby_bindir] + gem_paths.map { |p| File.join(p, "bin") }
+      end
+
+      # The first candidate that exists and is executable.
+      #
+      # @param gem_paths [Array<String>] gem paths to search
+      # @param ruby_bindir [String] the running Ruby's bindir
+      # @return [String, nil] path to rspec, or nil to let the caller fall back
+      #   to whatever is on PATH
+      def find(gem_paths = Gem.paths.path, ruby_bindir = RbConfig::CONFIG["bindir"])
+        candidate_bindirs(gem_paths, ruby_bindir)
+          .map { |dir| File.join(dir, "rspec") }
+          .find { |bin| File.exist?(bin) && File.executable?(bin) }
+      end
+    end
+  end
+end

--- a/lib/busser/serverspec/runner.rb
+++ b/lib/busser/serverspec/runner.rb
@@ -20,26 +20,12 @@ require "rake"
 require "rspec/core/rake_task"
 require "rbconfig" unless defined?(RbConfig)
 
+require_relative "rspec_binary"
+
 base_path = File.expand_path(ARGV.shift)
 
 RSpec::Core::RakeTask.new(:spec) do |t|
-  candidate_bindirs = []
-  # Current Ruby's default bindir
-  candidate_bindirs << RbConfig::CONFIG["bindir"]
-  # Search all Gem paths bindirs
-  candidate_bindirs << Gem.paths.path.map do |gem_path|
-    File.join(gem_path, "bin")
-  end
-
-  candidate_rspec_bins = candidate_bindirs.flatten.map do |bin_dir|
-    File.join(bin_dir, "rspec")
-  end
-
-  rspec_bin = candidate_rspec_bins.find do |candidate_rspec_bin|
-    FileTest.exist?(candidate_rspec_bin) &&
-      FileTest.executable?(candidate_rspec_bin)
-  end
-
+  rspec_bin = Busser::Serverspec::RspecBinary.find
   t.rspec_path = rspec_bin if rspec_bin
   t.rspec_opts = [
     "--color",

--- a/spec/busser/serverspec/rspec_binary_spec.rb
+++ b/spec/busser/serverspec/rspec_binary_spec.rb
@@ -1,0 +1,77 @@
+require_relative "../../spec_helper"
+
+require "fileutils"
+require "tmpdir"
+require "busser/serverspec/rspec_binary"
+
+describe Busser::Serverspec::RspecBinary do
+  def bindir_with_rspec(root, executable: true)
+    bin = File.join(root, "bin")
+    FileUtils.mkdir_p(bin)
+    path = File.join(bin, "rspec")
+    File.write(path, "#!/bin/sh\n")
+    File.chmod(executable ? 0o755 : 0o644, path)
+    path
+  end
+
+  describe ".candidate_bindirs" do
+    it "looks at the running Ruby's bindir before any gem path" do
+      dirs = Busser::Serverspec::RspecBinary.candidate_bindirs(["/gems/a"])
+      _(dirs.first).must_equal RbConfig::CONFIG["bindir"]
+    end
+
+    it "appends bin to each gem path" do
+      dirs = Busser::Serverspec::RspecBinary.candidate_bindirs(["/gems/a", "/gems/b"])
+      _(dirs.last(2)).must_equal ["/gems/a/bin", "/gems/b/bin"]
+    end
+
+    it "copes with no gem paths at all" do
+      _(Busser::Serverspec::RspecBinary.candidate_bindirs([]))
+        .must_equal [RbConfig::CONFIG["bindir"]]
+    end
+  end
+
+  describe ".find" do
+    # An empty stand-in for the running Ruby's bindir, so these do not depend on
+    # whether the host Ruby happens to have an rspec next to it.
+    let(:no_ruby_bin) { Dir.mktmpdir }
+    after { FileUtils.remove_entry(no_ruby_bin) if File.directory?(no_ruby_bin) }
+    it "returns the rspec in the first gem path that has one" do
+      Dir.mktmpdir do |a|
+        Dir.mktmpdir do |b|
+          bindir_with_rspec(a)
+          bindir_with_rspec(b)
+          _(Busser::Serverspec::RspecBinary.find([a, b], no_ruby_bin)).must_equal File.join(a, "bin", "rspec")
+        end
+      end
+    end
+
+    it "skips a gem path with no rspec" do
+      Dir.mktmpdir do |empty|
+        Dir.mktmpdir do |real|
+          bindir_with_rspec(real)
+          _(Busser::Serverspec::RspecBinary.find([empty, real], no_ruby_bin))
+            .must_equal File.join(real, "bin", "rspec")
+        end
+      end
+    end
+
+    # A non-executable file here would be handed to Rake as rspec_path and the
+    # run would die with a permission error rather than falling back to PATH.
+    it "skips a file that exists but is not executable" do
+      Dir.mktmpdir do |a|
+        Dir.mktmpdir do |b|
+          bindir_with_rspec(a, executable: false)
+          bindir_with_rspec(b)
+          _(Busser::Serverspec::RspecBinary.find([a, b], no_ruby_bin)).must_equal File.join(b, "bin", "rspec")
+        end
+      end
+    end
+
+    # nil is meaningful: the caller leaves rspec_path unset and Rake falls back
+    # to whatever rspec is on PATH.
+    it "returns nil when nothing is found, rather than a bogus path" do
+      Dir.mktmpdir { |dir| _(Busser::Serverspec::RspecBinary.find([dir], no_ruby_bin)).must_be_nil }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+require "minitest/autorun"
+require "mocha/minitest"


### PR DESCRIPTION
These plugins had no unit tests at all -- every check was an end-to-end cucumber
feature that boots busser, installs a plugin into a sandbox and runs a suite.
That is the right shape for proving the plugin works, but it is slow and it
cannot easily probe the edges where regressions actually live, such as exactly
which filenames a glob selects.

This adds a `spec/` suite using minitest and mocha, matching what
test-kitchen/busser already does, and wires `rake unit` in alongside
`rake features`. `rake test` runs both. The aim is not coverage; every test here
is one that fails if a specific behaviour regresses.

Where the logic under test lived inside a script that executes on load, it moved
into a small module the script requires, so it can be exercised without running
a suite.

## What is covered

Finding the rspec executable is the least obvious logic in this plugin. The
machine under test may have several Ruby installations and several gem paths,
and the point of the search is to avoid shelling out to whatever `rspec` is on
PATH -- which may belong to a different Ruby than the one serverspec was
installed into. It had no coverage at all.

It moved out of the runner script into `Busser::Serverspec::RspecBinary`, with
the running Ruby's bindir injectable so the tests do not depend on what the host
Ruby happens to have installed next to it.

Seven tests: the Ruby bindir is searched before any gem path; gem paths get
`bin` appended; an empty gem path list is handled; the first match wins; a gem
path without rspec is skipped; **a file that exists but is not executable is
skipped** (otherwise it would be handed to Rake as `rspec_path` and the run
would die on a permission error instead of falling back to PATH); and nothing
found returns `nil` rather than a bogus path, which is what lets the caller
leave `rspec_path` unset.

Verified they bite: dropping the executable check fails one.