### PR TITLE
docs: document every method with YARD and add a docs rake task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,3 +15,7 @@ group :test do
   gem "rake", ">= 13.4"
   gem "serverspec", ">= 2.43"
 end
+
+group :development do
+  gem "yard", ">= 0.9.37"
+end

--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,24 @@ Cucumber::Rake::Task.new(:features) do |t|
   t.cucumber_opts = ["features", "--format progress", "--fail-fast"]
 end
 
+# yard lives in the :development group, which CI omits when it runs the tests.
+# Requiring it unconditionally would make `rake test` fail there, so the real
+# task is only defined when yard is installed and a stub explains its absence
+# otherwise. Nothing in CI gates on documentation.
+begin
+  require "yard"
+
+  YARD::Rake::YardocTask.new(:doc) do |t|
+    t.files = ["lib/**/*.rb"]
+    t.options = ["--output-dir", "doc", "--markup", "markdown"]
+  end
+rescue LoadError
+  desc "Generate YARD documentation (install the development group first)"
+  task :doc do
+    abort "yard is not available. Run `bundle install --with development` first."
+  end
+end
+
 desc "Run all test suites"
 task test: %i{unit features}
 

--- a/lib/busser/runner_plugin/serverspec.rb
+++ b/lib/busser/runner_plugin/serverspec.rb
@@ -23,10 +23,17 @@ require "rubygems/dependency_installer"
 # @author HIGUCHI Daisuke <d-higuchi@creationline.com>
 #
 class Busser::RunnerPlugin::Serverspec < Busser::RunnerPlugin::Base
+  # Installs bundler onto the machine under test. Serverspec itself is left
+  # until #test, so a suite that pins its own version in a Gemfile is not
+  # made to download a second copy first.
   postinstall do
     install_gem("bundler")
   end
 
+  # Runs the suite's specs, installing the suite's own gems and serverspec
+  # first if they are not already present.
+  #
+  # @return [void]
   def test
     run_bundle_install
     install_serverspec
@@ -37,6 +44,10 @@ class Busser::RunnerPlugin::Serverspec < Busser::RunnerPlugin::Base
 
   private
 
+  # Installs the suite's own gems, if it ships a Gemfile. This is how a suite
+  # pins a particular serverspec version.
+  #
+  # @return [nil] if the suite has no Gemfile
   def run_bundle_install
     # Referred from busser-shindo
     gemfile_path = File.join(suite_path, "serverspec", "Gemfile")
@@ -52,6 +63,10 @@ class Busser::RunnerPlugin::Serverspec < Busser::RunnerPlugin::Base
     end
   end
 
+  # Installs serverspec unless some version is already available, so a version
+  # pinned by the suite's own Gemfile is left alone.
+  #
+  # @return [void]
   def install_serverspec
     Gem::Specification.reset
     if Array(Gem::Specification.find_all_by_name("serverspec")).size == 0

--- a/lib/busser/serverspec/version.rb
+++ b/lib/busser/serverspec/version.rb
@@ -16,7 +16,9 @@
 # limitations under the License.
 
 module Busser
+  # Namespace for the Serverspec Busser runner plugin.
   module Serverspec
+    # Version string for the Serverspec Busser runner plugin
     VERSION = "0.6.3".freeze
   end
 end


### PR DESCRIPTION
docs: document every method with YARD and add a docs rake task

Nothing in this repository carried API documentation beyond a stray author tag.
Every method now has a YARD comment covering what it does, what it takes, what
it returns, and -- where it matters -- why it is written the way it is. `yard
stats --private` reports 100% documented.

`rake doc` generates the HTML into `doc/`, which is already gitignored.

yard sits in the `:development` bundler group, which CI omits when it runs the
tests, so the Rakefile only defines the real task when yard is installed and
otherwise leaves a stub that says how to get it. **Nothing in CI gates on
documentation**, and `rake test` still works with the group omitted -- verified
by running it under `BUNDLE_WITHOUT=development`, the same setting the shared
workflow uses.