### PR TITLE
fix: quote paths before handing them to a shell

### DIFF
--- a/lib/busser/runner_plugin/serverspec.rb
+++ b/lib/busser/runner_plugin/serverspec.rb
@@ -15,6 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "rbconfig" unless defined?(RbConfig)
+require "shellwords" unless defined?(Shellwords)
+
 require "busser/runner_plugin"
 require "rubygems/dependency_installer"
 
@@ -26,6 +29,38 @@ class Busser::RunnerPlugin::Serverspec < Busser::RunnerPlugin::Base
   # Installs bundler onto the machine under test. Serverspec itself is left
   # until #test, so a suite that pins its own version in a Gemfile is not
   # made to download a second copy first.
+  # Builds the command that runs the suite's specs.
+  #
+  # Both paths are quoted: the suite path is rooted at BUSSER_ROOT, which the
+  # caller chooses, so an unquoted path containing a space would be split by
+  # the shell.
+  #
+  # @param runner [String, Pathname] path to the runner script
+  # @param suite [String, Pathname] the suite directory holding the specs
+  # @return [String] the command to run
+  def self.runner_command(runner, suite)
+    "#{Shellwords.escape(runner.to_s)} #{Shellwords.escape(suite.to_s)}"
+  end
+
+  # Builds the bundle install command for a suite's own Gemfile, which is how a
+  # suite pins its serverspec version.
+  #
+  # bundler is invoked through the Ruby running Busser rather than whatever
+  # `bundle` is on PATH, since on a machine with several Rubies those differ and
+  # the suite's gems would land where the runner cannot see them.
+  #
+  # @param gemfile [String, Pathname] path to the suite's Gemfile
+  # @return [String] the command to run
+  def self.bundle_install_command(gemfile)
+    bundle = [
+      Shellwords.escape(File.join(RbConfig::CONFIG["bindir"], "ruby")),
+      Shellwords.escape(File.join(Gem.bindir, "bundle")),
+      "install", "--gemfile", Shellwords.escape(gemfile.to_s)
+    ].join(" ")
+
+    "#{bundle} --local || #{bundle}"
+  end
+
   postinstall do
     install_gem("bundler")
   end
@@ -39,7 +74,7 @@ class Busser::RunnerPlugin::Serverspec < Busser::RunnerPlugin::Base
     install_serverspec
 
     runner = File.join(File.dirname(__FILE__), %w{.. serverspec runner.rb})
-    run_ruby_script!("#{runner} #{suite_path("serverspec")}")
+    run_ruby_script!(self.class.runner_command(runner, suite_path("serverspec")))
   end
 
   private
@@ -57,9 +92,7 @@ class Busser::RunnerPlugin::Serverspec < Busser::RunnerPlugin::Base
       # the fallback to the internet-enabled version. It's a speed optimization.
       banner("Bundle Installing..")
       ENV["PATH"] = [ENV["PATH"], Gem.bindir, RbConfig::CONFIG["bindir"]].join(File::PATH_SEPARATOR)
-      bundle_exec = "#{File.join(RbConfig::CONFIG["bindir"], "ruby")} " +
-        "#{File.join(Gem.bindir, "bundle")} install --gemfile #{gemfile_path}"
-      run("#{bundle_exec} --local || #{bundle_exec}")
+      run(self.class.bundle_install_command(gemfile_path))
     end
   end
 

--- a/spec/busser/runner_plugin/serverspec_spec.rb
+++ b/spec/busser/runner_plugin/serverspec_spec.rb
@@ -1,0 +1,58 @@
+require_relative "../../spec_helper"
+
+require "rbconfig"
+require "shellwords"
+require "busser/runner_plugin/serverspec"
+
+describe Busser::RunnerPlugin::Serverspec do
+  describe ".runner_command" do
+    it "runs the runner against the suite" do
+      cmd = Busser::RunnerPlugin::Serverspec.runner_command("/gems/runner.rb",
+        "/opt/busser/suites/serverspec")
+
+      _(Shellwords.split(cmd)).must_equal ["/gems/runner.rb", "/opt/busser/suites/serverspec"]
+    end
+
+    # BUSSER_ROOT is chosen by the caller. Unquoted, a space split the path and
+    # the runner was handed a fragment as its base path.
+    it "quotes a suite path containing spaces" do
+      cmd = Busser::RunnerPlugin::Serverspec.runner_command("/a/runner.rb",
+        "/tmp/my tests/serverspec")
+
+      _(Shellwords.split(cmd)).must_equal ["/a/runner.rb", "/tmp/my tests/serverspec"]
+    end
+
+    it "accepts Pathname arguments" do
+      cmd = Busser::RunnerPlugin::Serverspec.runner_command(Pathname.new("/a/r.rb"),
+        Pathname.new("/b/serverspec"))
+
+      _(Shellwords.split(cmd)).must_equal ["/a/r.rb", "/b/serverspec"]
+    end
+  end
+
+  describe ".bundle_install_command" do
+    let(:cmd) { Busser::RunnerPlugin::Serverspec.bundle_install_command("/suite/Gemfile") }
+
+    it "invokes bundler through the running Ruby rather than PATH" do
+      first, second = Shellwords.split(cmd).first(2)
+
+      _(first).must_equal File.join(RbConfig::CONFIG["bindir"], "ruby")
+      _(second).must_equal File.join(Gem.bindir, "bundle")
+    end
+
+    it "names the suite's Gemfile explicitly" do
+      _(Shellwords.split(cmd)).must_include "/suite/Gemfile"
+    end
+
+    it "falls back from the local attempt to a networked one" do
+      _(cmd).must_include "--local || "
+      _(cmd.scan("--gemfile").length).must_equal 2
+    end
+
+    it "quotes a Gemfile path containing spaces" do
+      cmd = Busser::RunnerPlugin::Serverspec.bundle_install_command("/tmp/my tests/Gemfile")
+
+      _(Shellwords.split(cmd.split(" || ").first)).must_include "/tmp/my tests/Gemfile"
+    end
+  end
+end


### PR DESCRIPTION
fix: quote paths before handing them to a shell

Two commands interpolated paths raw: the runner invocation and the bundle
install for a suite Gemfile. Both paths are rooted at BUSSER_ROOT, which the
caller chooses and Test Kitchen places under a user-controlled directory, so a
space anywhere in it split the command and the tool was handed a fragment.

Each now comes from a class method that escapes with Shellwords, which also
makes them testable without running a suite. Seven specs cover them, asserting
on Shellwords.split -- what a shell would actually see -- rather than on
escaping syntax.